### PR TITLE
Feature/log exceptions without flattenexception

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -19,7 +19,7 @@ class Configuration implements ConfigurationInterface {
     $treeBuilder = new TreeBuilder('hallo_verden_http_exceptions');
 
     $treeBuilder->getRootNode()
-      ->addDefaultChildrenIfNoneSet()
+      ->addDefaultsIfNotSet()
       ->children()
         ->arrayNode('exception_log')
           ->children()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -22,7 +22,7 @@ class Configuration implements ConfigurationInterface {
       ->children()
         ->arrayNode('exception_log')
           ->children()
-            ->booleanNode('use_flatten_exception')->end()
+            ->booleanNode('use_flatten_exception')->defaultTrue()->end()
           ->end()
         ->end()
       ->end();

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace HalloVerden\HttpExceptionsBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * Class Configuration
+ *
+ * @package HalloVerden\HttpExceptionsBundle\DependencyInjection
+ */
+class Configuration implements ConfigurationInterface {
+
+  /**
+   * @inheritDoc
+   */
+  public function getConfigTreeBuilder(): TreeBuilder {
+    $treeBuilder = new TreeBuilder('hallo_verden_http_exceptions');
+
+    $treeBuilder->getRootNode()
+      ->children()
+        ->arrayNode('exception_log')
+          ->children()
+            ->booleanNode('use_flatten_exception')->end()
+          ->end()
+        ->end()
+      ->end();
+
+    return $treeBuilder;
+  }
+
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -19,9 +19,9 @@ class Configuration implements ConfigurationInterface {
     $treeBuilder = new TreeBuilder('hallo_verden_http_exceptions');
 
     $treeBuilder->getRootNode()
-      ->addDefaultsIfNotSet()
       ->children()
         ->arrayNode('exception_log')
+          ->addDefaultsIfNotSet()
           ->children()
             ->booleanNode('use_flatten_exception')->defaultTrue()->end()
           ->end()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -19,6 +19,7 @@ class Configuration implements ConfigurationInterface {
     $treeBuilder = new TreeBuilder('hallo_verden_http_exceptions');
 
     $treeBuilder->getRootNode()
+      ->addDefaultChildrenIfNoneSet()
       ->children()
         ->arrayNode('exception_log')
           ->children()

--- a/DependencyInjection/HalloVerdenHttpExceptionsExtension.php
+++ b/DependencyInjection/HalloVerdenHttpExceptionsExtension.php
@@ -4,20 +4,28 @@
 namespace HalloVerden\HttpExceptionsBundle\DependencyInjection;
 
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Extension\Extension;
-use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use HalloVerden\HttpExceptionsBundle\Interfaces\Services\ExceptionLogServiceInterface;
+use HalloVerden\HttpExceptionsBundle\Services\ExceptionLogService;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
 
-class HalloVerdenHttpExceptionsExtension extends Extension {
+class HalloVerdenHttpExceptionsExtension extends ConfigurableExtension {
 
   /**
    * @inheritDoc
    * @throws \Exception
    */
-  public function load(array $configs, ContainerBuilder $container) {
+  protected function loadInternal(array $mergedConfig, ContainerBuilder $container) {
     $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
     $loader->load('services.yaml');
-  }
 
+    $exceptionLog = $container->getDefinition(ExceptionLogServiceInterface::class);
+    if ($exceptionLog->getClass() === ExceptionLogService::class) {
+      $exceptionLog->addArgument([
+        '$useFlattenException' => $mergedConfig['exception_log']['use_flatten_exception']
+      ]);
+    }
+  }
 }

--- a/DependencyInjection/HalloVerdenHttpExceptionsExtension.php
+++ b/DependencyInjection/HalloVerdenHttpExceptionsExtension.php
@@ -23,9 +23,7 @@ class HalloVerdenHttpExceptionsExtension extends ConfigurableExtension {
 
     $exceptionLog = $container->getDefinition(ExceptionLogServiceInterface::class);
     if ($exceptionLog->getClass() === ExceptionLogService::class) {
-      $exceptionLog->addArgument([
-        '$useFlattenException' => $mergedConfig['exception_log']['use_flatten_exception']
-      ]);
+      $exceptionLog->setArgument('$useFlattenException', $mergedConfig['exception_log']['use_flatten_exception']);
     }
   }
 }

--- a/Resources/config/hallo_verden_http_exceptions.yaml
+++ b/Resources/config/hallo_verden_http_exceptions.yaml
@@ -1,0 +1,3 @@
+hallo_verden_http_exceptions:
+  exception_log:
+    use_flatten_exception: false

--- a/Resources/config/hallo_verden_http_exceptions.yaml
+++ b/Resources/config/hallo_verden_http_exceptions.yaml
@@ -1,3 +1,3 @@
 hallo_verden_http_exceptions:
   exception_log:
-    use_flatten_exception: false
+    use_flatten_exception: true

--- a/Services/ExceptionLogService.php
+++ b/Services/ExceptionLogService.php
@@ -15,6 +15,15 @@ class ExceptionLogService implements ExceptionLogServiceInterface {
   const MESSAGE_ERROR = 'InternalServerError';
   const MESSAGE_INFO = 'Exception was thrown';
 
+  private bool $useFlattenException;
+
+  /**
+   * ExceptionLogService constructor.
+   */
+  public function __construct(bool $useFlattenException = true) {
+    $this->useFlattenException = $useFlattenException;
+  }
+
   /**
    * @param HttpExceptionInterface $exception
    */
@@ -23,12 +32,26 @@ class ExceptionLogService implements ExceptionLogServiceInterface {
       return;
     }
 
-    $context = FlattenExceptionHelper::createFromThrowable($exception)->toArray();
+    $context = $this->createContext($exception);
+
     if ($exception->getStatusCode() >= 500) {
       $this->logger->error(self::MESSAGE_ERROR, $context);
     } else {
       $this->logger->info(self::MESSAGE_INFO, $context);
     }
+  }
+
+  /**
+   * @param HttpExceptionInterface $exception
+   *
+   * @return array
+   */
+  protected function createContext(HttpExceptionInterface $exception): array {
+    if ($this->useFlattenException) {
+      return FlattenExceptionHelper::createFromThrowable($exception)->toArray();
+    }
+
+    return ['httpException' => $exception];
   }
 
 }


### PR DESCRIPTION
Ability to log exceptions without using flattenexception.
Adds the exception to log context and the logger will handle normalization of this exception.

new config:
```yaml
hallo_verden_http_exceptions:
  exception_log:
    use_flatten_exception: true
```